### PR TITLE
Return an Ember.Object/Ember.Comparable extension of moment.js

### DIFF
--- a/moment-shim.js
+++ b/moment-shim.js
@@ -1,6 +1,42 @@
 (function() {
 /* globals define, moment */
 
+  var ComparableMoment = Ember.Object.extend(Ember.Comparable, moment.fn, {
+    compare: function(a, b) {
+      if (moment.isMoment(a) && moment.isMoment(b) && a.isBefore(b)) {
+        return -1;
+      } else if (moment.isMoment(a) && moment.isMoment(b) && a.isAfter(b)) {
+        return 1;
+      } else if (moment.isMoment(a) && !moment.isMoment(b)) {
+        return 1;
+      } else if (moment.isMoment(b)) {
+        return -1;
+      }
+
+      return 0;
+    }
+  });
+
+  var comparableMoment = function() {
+    return ComparableMoment.create(moment.apply(this, arguments));
+  };
+
+  for (var momentProp in moment) {
+    if (moment.hasOwnProperty(momentProp)) {
+      comparableMoment[momentProp] = moment[momentProp];
+    }
+  }
+
+  comparableMoment.utc = function() {
+    return ComparableMoment.create(moment.utc.apply(this, arguments));
+  };
+
+  ComparableMoment.reopen({
+    clone: function() {
+      return comparableMoment(this);
+    }
+  });
+
   function generateModule(name, values) {
     define(name, [], function() {
       'use strict';
@@ -9,5 +45,5 @@
     });
   }
 
-  generateModule('moment', { 'default': moment});
+  generateModule('moment', { 'default': comparableMoment});
 })();


### PR DESCRIPTION
One downside to moment objects is that they don't work with Ember.compare(), which means sorting on moment objects is a giant pain. I've been using the above wrapper at work for a while to wrap the moment objects I get back from moment() or moment.utc().

I've run these changes against the test suite in ember-moment as well as a few additional tests around the comparable functionality and everything is passing.
