### PR TITLE
Remove EnumerableUtils

### DIFF
--- a/moment-shim.js
+++ b/moment-shim.js
@@ -28,7 +28,7 @@
   }
 
   // Wrap global moment methods that return a full moment object
-  Ember.EnumerableUtils.forEach(['utc', 'unix'], function(method) {
+  ['utc', 'unix'].forEach(function(method) {
     comparableMoment[method] = function() {
       return ComparableMoment.create(moment[method].apply(this, arguments));
     };


### PR DESCRIPTION
Ember 2.0 has removed EnumerableUtils causing ember-cli-moment-shim to fail
