### PR TITLE
Moving bower dependencies to npm.

### DIFF
--- a/blueprints/ember-cli-moment-shim/index.js
+++ b/blueprints/ember-cli-moment-shim/index.js
@@ -10,7 +10,7 @@ module.exports = {
   afterInstall: function() {
     // we need to install moment-timezone via bower since npmignore
     // ignores `moment-timezone/builds/*`
-    return this.addBowerPackagesToProject([
+    return this.addPackagesToProject([
       { name: 'moment', target: '^2.8.0' },
       { name: 'moment-timezone', target: '^0.5.0' }
     ]);

--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,6 @@
     "ember-resolver": "~0.1.18",
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "moment": "^2.8.0",
-    "moment-timezone": "^0.5.0",
     "qunit": "~1.17.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var defaults = require('lodash.defaults');
 var rename = require('broccoli-stew').rename;
 var existsSync = require('exists-sync');
 var chalk = require('chalk');
+var path = require('path');
 
 module.exports = {
   name: 'moment',
@@ -51,7 +52,7 @@ module.exports = {
 
   getConfig: function() {
     var projectConfig = ((this.project.config(process.env.EMBER_ENV) || {}).moment || {});
-    var momentPath = this.project.bowerDirectory + '/moment';
+    var momentPath = path.dirname(require.resolve('moment'));
 
     var config = defaults(projectConfig, {
       momentPath: momentPath,
@@ -130,7 +131,8 @@ module.exports = {
     }
 
     if (options.includeTimezone) {
-      var timezonePath = [this.project.bowerDirectory, 'moment-timezone', 'builds'];
+      var momentTimezonePath = path.dirname(require.resolve('moment-timezone'));
+      var timezonePath = [momentTimezonePath, 'builds'];
 
       switch(options.includeTimezone) {
         case 'all':
@@ -147,7 +149,7 @@ module.exports = {
           break;
       }
 
-      trees.push(rename(new Funnel(this.project.bowerDirectory + '/moment-timezone/builds', {
+      trees.push(rename(new Funnel(momentTimezonePath + '/builds', {
         files: [timezonePath[timezonePath.length - 1]]
       }), function(filepath) {
         return 'moment-timezone/tz.js';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-try": "0.0.8"
+    "ember-try": "0.0.8",
+    "moment": "^2.8.0",
+    "moment-timezone": "^0.5.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
I'm working on building some composed addons using other addons that depend on `ember-cli-moment-shim` and `ember-cli-moment-shim`'s bower dependencies making things more difficult than I'd hoped because my composed addon would have to have a blueprint to install `moment` and `moment-timezone` with bower.

Since `moment-timezone` now publishes to npm with the `builds` directory included, I tried my hand at moving those dependencies to npm.
