### PR TITLE
FastBoot Support

### DIFF
--- a/assets/fastboot-moment-timezone.js
+++ b/assets/fastboot-moment-timezone.js
@@ -1,0 +1,5 @@
+(function() {
+  define('moment', ['exports'], function(self) {
+    self['default'] = FastBoot.require('moment-timezone');
+  });
+})();

--- a/blueprints/ember-cli-moment-shim/index.js
+++ b/blueprints/ember-cli-moment-shim/index.js
@@ -1,3 +1,4 @@
+/*jshint node:true*/
 'use strict';
 
 module.exports = {
@@ -5,12 +6,5 @@ module.exports = {
     // this prevents an error when the entityName is
     // not specified (since that doesn't actually matter
     // to us
-  },
-
-  afterInstall: function() {
-    return this.addPackagesToProject([
-      { name: 'moment', target: '^2.8.0' },
-      { name: 'moment-timezone', target: '^0.5.0' }
-    ]);
   }
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "chalk": "^1.1.1",
     "ember-cli-babel": "^5.0.0",
     "exists-sync": "0.0.3",
-    "lodash.defaults": "^3.1.2"
+    "lodash.defaults": "^3.1.2",
+    "moment": "^2.8.0",
+    "moment-timezone": "^0.5.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
@@ -42,9 +44,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-try": "0.0.8",
-    "moment": "^2.8.0",
-    "moment-timezone": "^0.5.0"
+    "ember-try": "0.0.8"
   },
   "keywords": [
     "ember-addon",
@@ -53,6 +53,7 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config",
+    "fastBootDependencies": ["moment", "moment-timezone"],
     "before": [
       "ember-moment"
     ]


### PR DESCRIPTION
Uses Node version of `moment-timezone` if running under FastBoot.

The Node version of `moment-timezone` loads all locales/timezones 
so there’s no need to honour any of the configuration.

FastBoot requires its whitelisted dependencies to be in `dependencies` 
vs `devDependencies` so moved them out of the blueprint. 
