### PR TITLE
Fix deprecation `fastBootDependencies has been replaced with fastboot…

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "fastBootDependencies": [
+    "fastbootDependencies": [
       "moment",
       "moment-timezone"
     ],


### PR DESCRIPTION
…Dependencies`.
