### PR TITLE
Add failing test for expected Ember.computed.sort behavior

### DIFF
--- a/tests/unit/utils/moment-export-test.js
+++ b/tests/unit/utils/moment-export-test.js
@@ -24,7 +24,6 @@ test('moment compare functions property', (assert) => {
   assert.equal(instanceB.compare(instanceB, instanceA), 1);
 });
 
-
 test('moment tz fn exists', (assert) => {
   assert.equal(typeof moment.tz, 'function');
 });
@@ -43,4 +42,21 @@ test('moment.utc is a class function', (assert) => {
 
 test('moment().clone is an instance function', (assert) => {
   assert.equal(typeof moment().clone, 'function');
+});
+
+test('ember computed sort can work with exported moment', (assert) => {
+  const ObjClass = Ember.Object.extend({
+    datesSortParam: ['date:asc'],
+    sortedDateContainers: Ember.computed.sort('dateContainers', 'datesSortParam')
+  });
+
+  const obj = ObjClass.create({dateContainers: Ember.A([
+    {date: moment(20000)},
+    {date: moment(0)},
+    {date: moment(10000)}
+  ])});
+
+  assert.equal(Number(obj.get('sortedDateContainers')[0].date), 0);
+  assert.equal(Number(obj.get('sortedDateContainers')[1].date), 10000);
+  assert.equal(Number(obj.get('sortedDateContainers')[2].date), 20000);
 });


### PR DESCRIPTION
Ember.computed sort is not working as expected since 3.0.0 version