### PR TITLE
Improve upgrade description (and fix typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import moment from 'moment';
 
 ## Upgrading
 
-Whenever an upgrading ember-cli-moment-shim, be sure to rerun the generator manually if not installed via `ember install`.  To do this, `ember g ember-cli-moment-shim`
+Be sure to rerun the default blueprint with `ember g ember-cli-moment-shim` if upgrading by bumping the version number in package.json.
 
 ## Enabling moment-timezone
 


### PR DESCRIPTION
Spiffs up the Upgrading section while eliminating the typo in "Whenever an upgrading ember-cli-moment-shim"