### PR TITLE
Implement Ember.Copyable without export an Ember.Object

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -45,7 +45,7 @@ function createAugmentedMomentFrom(fn) {
   const augmentedMoment = function() {
     const m = fn(...arguments);
     const meta = Ember.meta(m);
-    meta.writeMixins(Ember.guidFor(Ember.Copyable), Ember.Copyable);
+    meta.addMixin(Ember.Copyable);
 
     return m;
   }

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,61 @@
 import moment from './lib';
+import Ember from 'ember';
+
+
+function hasOwnProp(a, b) {
+  return Object.prototype.hasOwnProperty.call(a, b);
+}
+
+function extend(a, b) {
+  for (let propName in b) {
+    if (hasOwnProp(b,propName)) {
+      Object.defineProperty(a,propName, {
+        enumerable: true,
+        configurable: true,
+        get() {
+          return b[propName];
+        },
+        set(newValue) {
+          b[propName] = newValue;
+        }
+      });
+    }
+  }
+
+  // non-enumerable property
+  ['toString', 'valueOf'].forEach(propName => {
+    if (hasOwnProp(b, propName)) {
+      Object.defineProperty(a, propName, {
+        enumerable: false,
+        configurable: true,
+        get() {
+          return b[propName];
+        },
+        set(newValue) {
+          b[propName] = newValue;
+        }
+      });
+    }
+  });
+
+  return a;
+}
+
+function createAugmentedMomentFrom(fn) {
+  const augmentedMoment = function() {
+    const m = fn(...arguments);
+    const meta = Ember.meta(m);
+    meta.writeMixins(Ember.guidFor(Ember.Copyable), Ember.Copyable);
+
+    return m;
+  }
+
+  augmentedMoment.prototype = moment.prototype;
+
+  extend(augmentedMoment, moment);
+
+  return augmentedMoment;
+}
 
 function compare(a, b) {
   if (moment.isMoment(a) && moment.isMoment(b)) {
@@ -18,7 +75,13 @@ moment.prototype.compare = compare;
 moment.compare = compare;
 
 moment.prototype.clone = function clone() {
-  return moment(this);
+  return augmentedMoment(this);
 }
 
-export default moment;
+moment.prototype.copy = function copy(deep) {
+  return this.clone();
+}
+
+const augmentedMoment = createAugmentedMomentFrom(moment);
+
+export default augmentedMoment;

--- a/addon/index.js
+++ b/addon/index.js
@@ -84,4 +84,8 @@ moment.prototype.copy = function copy(deep) {
 
 const augmentedMoment = createAugmentedMomentFrom(moment);
 
+['utc', 'unix'].forEach((methodName) => {
+  augmentedMoment[methodName] = createAugmentedMomentFrom(moment[methodName]);
+});
+
 export default augmentedMoment;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-cli": "~3.0.0",
+    "ember-cli": "^3.1.4",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",
@@ -57,7 +57,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~3.0.0",
+    "ember-source": "^3.2.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/unit/utils/moment-copyable-test.js
+++ b/tests/unit/utils/moment-copyable-test.js
@@ -1,3 +1,4 @@
+import { copy } from '@ember/object/internals';
 import { test, module } from 'qunit';
 import moment from 'moment';
 import Ember from 'ember';
@@ -17,7 +18,7 @@ test('moment() implements Copyable mixin and "copy" fn exists', (assert) => {
 
 test('moment()\'s copy implements Copyable mixin and "copy" fn exists', (assert) => {
   const instance = moment();
-  const instanceCopy = Ember.copy(instance);
+  const instanceCopy = copy(instance);
 
   assert.ok(Ember.Copyable.detect(instanceCopy));
   assert.equal(typeof instanceCopy.copy, 'function');
@@ -39,7 +40,7 @@ test('moment.utc() implements Copyable mixin and "copy" fn exists', (assert) => 
 
 test('Copy a moment instance and modify it', (assert) => {
   const instance = moment();
-  const instanceCopy = Ember.copy(instance);
+  const instanceCopy = copy(instance);
 
   instanceCopy.add(7, 'd');
 

--- a/tests/unit/utils/moment-copyable-test.js
+++ b/tests/unit/utils/moment-copyable-test.js
@@ -7,3 +7,27 @@ module('Unit | moment copyable');
 test('moment exports', (assert) => {
   assert.ok(moment, 'moment exports an object');
 });
+
+test('moment() implements Copyable mixin and "copy" fn exists', (assert) => {
+  const instance = moment();
+
+  assert.ok(Ember.Copyable.detect(instance));
+  assert.equal(typeof instance.copy, 'function');
+});
+
+test('moment()\'s copy implements Copyable mixin and "copy" fn exists', (assert) => {
+  const instance = moment();
+  const instanceCopy = Ember.copy(instance);
+
+  assert.ok(Ember.Copyable.detect(instanceCopy));
+  assert.equal(typeof instanceCopy.copy, 'function');
+})
+
+test('Copy a moment instance and modify it', (assert) => {
+  const instance = moment();
+  const instanceCopy = Ember.copy(instance);
+
+  instanceCopy.add(7, 'd');
+
+  assert.notOk(instanceCopy.isSame(instance), "Modified copy is not identical to the original.");
+})

--- a/tests/unit/utils/moment-copyable-test.js
+++ b/tests/unit/utils/moment-copyable-test.js
@@ -23,6 +23,20 @@ test('moment()\'s copy implements Copyable mixin and "copy" fn exists', (assert)
   assert.equal(typeof instanceCopy.copy, 'function');
 })
 
+test('moment.unix() implements Copyable mixin and "copy" fn exists', (assert) => {
+  const instance = moment.unix();
+
+  assert.ok(Ember.Copyable.detect(instance));
+  assert.equal(typeof instance.copy, 'function');
+});
+
+test('moment.utc() implements Copyable mixin and "copy" fn exists', (assert) => {
+  const instance = moment.utc();
+
+  assert.ok(Ember.Copyable.detect(instance));
+  assert.equal(typeof instance.copy, 'function');
+});
+
 test('Copy a moment instance and modify it', (assert) => {
   const instance = moment();
   const instanceCopy = Ember.copy(instance);

--- a/tests/unit/utils/moment-copyable-test.js
+++ b/tests/unit/utils/moment-copyable-test.js
@@ -1,0 +1,9 @@
+import { test, module } from 'qunit';
+import moment from 'moment';
+import Ember from 'ember';
+
+module('Unit | moment copyable');
+
+test('moment exports', (assert) => {
+  assert.ok(moment, 'moment exports an object');
+});


### PR DESCRIPTION
Hello,

Here is a PR which "implements" `Ember.Copyable` without encapsulating moment object in an Ember.Object (see #148). All unit tests are OK.