### PR TITLE
Remove Upgrading section that mentions blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ import moment from 'moment';
 * Trim your build sizes by bundling locales & timezones data through simple configuration
 * FastBoot support
 
-## Upgrading
-
-Be sure to rerun the default blueprint with `ember g ember-cli-moment-shim` if upgrading by bumping the version number in package.json.
-
 ## Enabling moment-timezone
 
 ```js


### PR DESCRIPTION
The Upgrading section in README.md references a default blueprint that doesn't exist anymore, so the section is unneeded.