### PR TITLE
Support including moment locales as a single module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,20 +43,33 @@ function getLocaleDefinitionModules(requestingTree) {
   }
 
   if (singleModule) {
+    // Turn the locales into a hash key/value pairs.
+    const keyValuePairs = map(localeTree, function(content, relativePath) {
+      const locale = path.basename(relativePath, '.js');
+      return `'${locale}': function() { ${content} },`;
+    });
+
+    // This function becomes defineLocale(locale);
     const header = `
-      export default function() {
+      export default function(locale) {
         if (typeof FastBoot === 'undefined') {
+          const locales = {
     `;
     const footer = `
+          };
+
+          if (locales[locale]) {
+            locales[locale]();
+          }
         }
       }
     `;
 
-    const concatenatedDefinitionIIFEs = concat(localeTree, {
+    const concatenatedDefinitionIIFEs = concat(keyValuePairs, {
       header,
       footer,
       inputFiles: ['**/*'],
-      outputFile: 'ember-cli-moment-shim/define-locales.js'
+      outputFile: 'ember-cli-moment-shim/define-locale.js'
     });
 
     let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');

--- a/index.js
+++ b/index.js
@@ -9,11 +9,65 @@ const defaults = require('lodash.defaults');
 const funnel = require('broccoli-funnel');
 const existsSync = require('exists-sync');
 const stew = require('broccoli-stew');
+const concat = require('broccoli-concat');
 const chalk = require('chalk');
 const path = require('path');
 
 const rename = stew.rename;
 const map = stew.map;
+
+function getLocaleDefinitionModules(requestingTree) {
+  let options = this._options;
+  const singleModule = options.singleModule;
+
+  if (requestingTree === 'addon' && !singleModule) {
+    return;
+  }
+
+  if (requestingTree === 'vendor' && singleModule) {
+    return;
+  }
+
+  let localeTree;
+  if (
+    Array.isArray(options.includeLocales) &&
+    options.includeLocales.length
+  ) {
+    localeTree = funnel(this.momentNode, {
+      srcDir: 'locale',
+      destDir: 'moment/locales',
+      include: options.includeLocales.map(
+        locale => new RegExp(locale + '.js$')
+      )
+    });
+  }
+
+  if (singleModule) {
+    const header = `
+      export default function() {
+        if (typeof FastBoot === 'undefined') {
+    `;
+    const footer = `
+        }
+      }
+    `;
+
+    const concatenatedDefinitionIIFEs = concat(localeTree, {
+      header,
+      footer,
+      inputFiles: ['**/*'],
+      outputFile: 'ember-cli-moment-shim/define-locales.js'
+    });
+
+    let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');
+    return babelAddon.transpileTree(concatenatedDefinitionIIFEs);
+  } else {
+    return map(
+      localeTree,
+      content => `if (typeof FastBoot === 'undefined') { ${content} }`
+    );
+  }
+}
 
 module.exports = {
   name: 'moment',
@@ -59,7 +113,7 @@ module.exports = {
         { prepend: true }
       );
     } else {
-      if (Array.isArray(options.includeLocales)) {
+      if (Array.isArray(options.includeLocales) && !options.singleModule) {
         options.includeLocales.forEach(locale => {
           this.import('vendor/moment/locales/' + locale + '.js', {
             prepend: true
@@ -82,6 +136,7 @@ module.exports = {
       (this.project.config(process.env.EMBER_ENV) || {}).moment || {};
     let momentPath = path.dirname(require.resolve('moment'));
     let config = defaults(projectConfig, {
+      singleModule: false,
       momentPath: momentPath,
       includeTimezone: null,
       includeLocales: []
@@ -144,13 +199,18 @@ module.exports = {
     return mergeTrees(trees);
   },
 
-  treeForVendor(vendorTree) {
+  treeForAddon() {
+    const superValue = this._super.apply(this, arguments);
+    const definitionModules = getLocaleDefinitionModules.call(this, 'addon');
+    return mergeTrees([superValue, definitionModules].filter(Boolean));
+  },
+
+  treeForVendor() {
     let trees = [];
     let options = this._options;
 
-    if (vendorTree) {
-      trees.push(vendorTree);
-    }
+    const superValue = this._super.apply(this, arguments);
+    trees.push(superValue);
 
     trees.push(
       funnel(this.momentNode, {
@@ -161,21 +221,6 @@ module.exports = {
         )
       })
     );
-
-    if (
-      Array.isArray(options.includeLocales) &&
-      options.includeLocales.length
-    ) {
-      let localeTree = funnel(this.momentNode, {
-        srcDir: 'locale',
-        destDir: 'moment/locales',
-        include: options.includeLocales.map(
-          locale => new RegExp(locale + '.js$')
-        )
-      });
-
-      trees.push(localeTree);
-    }
 
     if (options.includeTimezone) {
       let timezonePath;
@@ -227,8 +272,11 @@ module.exports = {
       );
     }
 
+    const definitionModules = getLocaleDefinitionModules.call(this, 'vendor');
+    trees.push(definitionModules);
+
     return map(
-      mergeTrees(trees),
+      mergeTrees(trees.filter(Boolean)),
       content => `if (typeof FastBoot === 'undefined') { ${content} }`
     );
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
+    "broccoli-concat": "^3.2.2",
     "broccoli-funnel": "^2.0.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-source": "^1.1.0",


### PR DESCRIPTION
In `treeForVendor` you load the moment locales. Each of those moment locales are an IIFE, which calls `defineLocale`. This wouldn't be a problem generally except that, at the end of `defineLocale` inside of moment.js (https://github.com/moment/moment/blob/f6c70690acc5580b8345caa83a3f2c3f2e2093d6/src/lib/locale/locales.js#L132) it sets the intrinsic locale to the most-recently-defined locale.

As a consequence the `globalLocale` for `moment` is set at an arbitrary time during boot. This is currently a problem because it is possible that the `this.get('moment').setLocale(actualDesiredLocale);` code runs before the IIFEs have executed, which will clobber the `globalLocale` for moment.

Given that these are all IIFE's I've modified it so that there is a way to opt in to having these appear inside of a single module that can be run at a known time.

This will allow you to do something like this with your code:

```javascript
import defineLocales from 'ember-cli-moment-shim/define-locales';

defineLocales();
this.get('moment').setLocale(actualDesiredLocale);
```

Does this seem reasonable?