### PR TITLE
Bundle un-minified assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,20 +30,14 @@ module.exports = {
 
     if (options.includeTimezone) {
       this.import(
-        {
-          development: 'vendor/moment-timezone/tz.js',
-          production: 'vendor/moment-timezone/tz.min.js'
-        },
+        'vendor/moment-timezone/tz.js',
         { prepend: true }
       );
     }
 
     if (typeof options.includeLocales === 'boolean' && options.includeLocales) {
       this.import(
-        {
-          development: 'vendor/moment/min/moment-with-locales.js',
-          production: 'vendor/moment/min/moment-with-locales.min.js'
-        },
+        'vendor/moment/moment-with-locales.js',
         { prepend: true }
       );
     } else {
@@ -56,10 +50,7 @@ module.exports = {
       }
 
       this.import(
-        {
-          development: 'vendor/moment/moment.js',
-          production: 'vendor/moment/min/moment.min.js'
-        },
+        'vendor/moment/moment.js',
         { prepend: true }
       );
     }


### PR DESCRIPTION
The ember build will handle minification and mangling in production
depending on the apps configuration so it doesn't need to be done here.

Interestingly this results in ~4kb less JS (gzipped) in vendor for my app. I guess the double minification causes bloat.

Fixes #183